### PR TITLE
Enable usage as library

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,9 @@
+ The MIT License (MIT)
+
+Copyright © 2024 Johan Dewe
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -3,3 +3,31 @@
 A Go output tracker for creating Nullable infrastructure.
 
 Inspired by https://www.jamesshore.com/v2/projects/nullables/testing-without-mocks
+
+## Usage
+
+```go
+package log
+
+import "github.com/dewe/go-outputtracker"
+
+type Log struct {
+	listener *outputtracker.OutputListener[LogData]
+}
+
+func CreateLog() *Log {
+	return &Log{listener: outputtracker.CreateListener[LogData]()}
+}
+
+// TrackOutput creates the output tracker
+func (l *Log) TrackOutput() *outputtracker.OutputTracker[LogData] {
+	return l.listener.CreateTracker()
+}
+
+func (l *Log) Info(data LogData) {
+	// ...
+
+	// Emit the event
+	l.listener.Track(data)
+}
+```

--- a/outputlistener.go
+++ b/outputlistener.go
@@ -6,6 +6,10 @@ type OutputListener[T any] struct {
 	listeners []*OutputTracker[T]
 }
 
+func CreateListener[T any]() *OutputListener[T] {
+	return &OutputListener[T]{listeners: make([]*OutputTracker[T], 0)}
+}
+
 func (ol *OutputListener[T]) CreateTracker() *OutputTracker[T] {
 	tracker := &OutputTracker[T]{outputListener: ol}
 	ol.listeners = append(ol.listeners, tracker)


### PR DESCRIPTION
This PR basically adds a constructor for `OutputListener`, which enables the usage of this code as a library in external projects. I have also taken the liberty of including a license and some usage instructions. I couldn't find any reference to any license on the repo, so I've chose to use MIT because it was the one originally chosen by James Shore and Ted Young for the Java code. Please make sure to check the name used in the copyright notice.